### PR TITLE
fix(ci): allow npm token fallback

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -62,7 +62,7 @@ jobs:
           node-version: '24'
           cache: npm
       - name: Install npm with Trusted Publishing support
-        run: npm install --global npm@11.5.1
+        run: npm install --global npm@11.15.0
       - name: Install dependencies
         run: npm ci --ignore-scripts
       - name: Install Rust
@@ -70,11 +70,13 @@ jobs:
       - name: Build and verify this native runtime
         run: npm --prefix packages/cli run build:native
       - name: Configure npm token fallback for first publication
-        if: ${{ secrets.NPM_TOKEN != '' }}
         shell: bash
-        run: npm config set //registry.npmjs.org/:_authToken "$NPM_TOKEN"
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          if [ -n "$NPM_TOKEN" ]; then
+            npm config set //registry.npmjs.org/:_authToken "$NPM_TOKEN"
+          fi
       - name: Publish native runtime
         run: node scripts/release/publish-package.mjs "packages/cli/npm/tokenless-native-${{ matrix.platform }}-${{ matrix.arch }}"
 
@@ -89,15 +91,17 @@ jobs:
           node-version: '24'
           cache: npm
       - name: Install npm with Trusted Publishing support
-        run: npm install --global npm@11.5.1
+        run: npm install --global npm@11.15.0
       - name: Install dependencies
         run: npm ci --ignore-scripts
       - name: Configure npm token fallback for first publication
-        if: ${{ secrets.NPM_TOKEN != '' }}
         shell: bash
-        run: npm config set //registry.npmjs.org/:_authToken "$NPM_TOKEN"
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          if [ -n "$NPM_TOKEN" ]; then
+            npm config set //registry.npmjs.org/:_authToken "$NPM_TOKEN"
+          fi
       - name: Publish universal CLI after every native runtime
         run: node scripts/release/publish-package.mjs packages/cli
 


### PR DESCRIPTION
Fixes GitHub Actions expression validation for the one-time npm token fallback. The release marker remains pending; once this merges, rerunning the publish workflow will build and publish the pending 0.1.2 release.