### PR TITLE
fix(ci): run npm through Windows shell

### DIFF
--- a/scripts/release/publish-package.mjs
+++ b/scripts/release/publish-package.mjs
@@ -11,10 +11,15 @@ if (typeof manifest.name !== 'string' || typeof manifest.version !== 'string') {
   throw new Error(`${manifestPath} must declare a package name and version.`)
 }
 
-const npm = process.platform === 'win32' ? 'npm.cmd' : 'npm'
+const npm = 'npm'
+const npmOptions = {
+  encoding: 'utf8',
+  // npm.cmd is not directly executable by child_process on Windows.
+  shell: process.platform === 'win32',
+}
 const packageSpec = `${manifest.name}@${manifest.version}`
 const lookup = spawnSync(npm, ['view', packageSpec, 'version', '--json', '--registry=https://registry.npmjs.org'], {
-  encoding: 'utf8',
+  ...npmOptions,
 })
 
 if (lookup.status === 0) {
@@ -31,7 +36,7 @@ if (!/E404|404 Not Found/.test(`${lookup.stdout}\n${lookup.stderr}`)) {
 }
 
 const publish = spawnSync(npm, ['publish', packageDirectory, '--access=public'], {
-  encoding: 'utf8',
+  ...npmOptions,
   stdio: 'inherit',
 })
 if (publish.status !== 0) process.exit(publish.status ?? 1)

--- a/test/release-contract.test.mjs
+++ b/test/release-contract.test.mjs
@@ -61,6 +61,11 @@ test('npm publishing is marker-gated, platform-complete, and cleans up in a seco
   }
 })
 
+test('npm publisher invokes Windows npm through a shell', () => {
+  const publisher = readText('scripts/release/publish-package.mjs')
+  assert.match(publisher, /shell: process\.platform === 'win32'/)
+})
+
 test('publish verification is a no-op without the tracked release marker', () => {
   const pending = path.join(root, '.changeset', 'publish-pending.json')
   assert.equal(fs.existsSync(pending), false)


### PR DESCRIPTION
Fix Windows native package publishing by invoking npm through a shell, and add a release-contract check.