### PR TITLE
fix(ci): install release dependencies after native publish

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -63,8 +63,6 @@ jobs:
           cache: npm
       - name: Install npm with Trusted Publishing support
         run: npm install --global npm@11.15.0
-      - name: Install dependencies
-        run: npm ci --ignore-scripts
       - name: Install Rust
         run: rustup toolchain install stable --profile minimal
       - name: Build and verify this native runtime
@@ -93,7 +91,11 @@ jobs:
       - name: Install npm with Trusted Publishing support
         run: npm install --global npm@11.15.0
       - name: Install dependencies
-        run: npm ci --ignore-scripts
+        run: |
+          # Native packages are published immediately before this job, so refresh
+          # their optional-dependency entries before performing a clean install.
+          npm install --package-lock-only --ignore-scripts
+          npm ci --ignore-scripts
       - name: Configure npm token fallback for first publication
         shell: bash
         env:
@@ -113,6 +115,9 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
       - name: Remove the published release marker in a second commit
         env:
           VERSION: ${{ needs.prepare.outputs.version }}
@@ -123,6 +128,8 @@ jobs:
           git checkout -B main origin/main
           node scripts/release/verify-pending.mjs /tmp/release-output
           grep -Fx "version=$VERSION" /tmp/release-output
+          npm install --package-lock-only --ignore-scripts
           git rm .changeset/publish-pending.json
+          git add package-lock.json
           git commit -m "chore(release): clear publish marker for tokenless@$VERSION"
           git push origin HEAD:main

--- a/test/release-contract.test.mjs
+++ b/test/release-contract.test.mjs
@@ -52,7 +52,9 @@ test('npm publishing is marker-gated, platform-complete, and cleans up in a seco
   assert.match(publish, /id-token: write/)
   assert.match(publish, /\.changeset\/publish-pending\.json/)
   assert.match(publish, /needs: \[prepare, publish-native\]/)
+  assert.match(publish, /npm install --package-lock-only --ignore-scripts/)
   assert.match(publish, /git rm \.changeset\/publish-pending\.json/)
+  assert.match(publish, /git add package-lock\.json/)
   for (const [platform, arch] of [
     ['darwin', 'arm64'], ['darwin', 'x64'], ['linux', 'arm64'],
     ['linux', 'x64'], ['win32', 'arm64'], ['win32', 'x64'],


### PR DESCRIPTION
Native package builds do not need Node dependencies. Refresh the lockfile only after all native packages are published, then persist it with the marker cleanup commit.