### PR TITLE
fix(ci): regenerate release lockfile

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -94,6 +94,7 @@ jobs:
         run: |
           # Native packages are published immediately before this job, so refresh
           # their optional-dependency entries before performing a clean install.
+          rm package-lock.json
           npm install --package-lock-only --ignore-scripts
           npm ci --ignore-scripts
       - name: Configure npm token fallback for first publication
@@ -128,6 +129,7 @@ jobs:
           git checkout -B main origin/main
           node scripts/release/verify-pending.mjs /tmp/release-output
           grep -Fx "version=$VERSION" /tmp/release-output
+          rm package-lock.json
           npm install --package-lock-only --ignore-scripts
           git rm .changeset/publish-pending.json
           git add package-lock.json

--- a/test/release-contract.test.mjs
+++ b/test/release-contract.test.mjs
@@ -52,6 +52,7 @@ test('npm publishing is marker-gated, platform-complete, and cleans up in a seco
   assert.match(publish, /id-token: write/)
   assert.match(publish, /\.changeset\/publish-pending\.json/)
   assert.match(publish, /needs: \[prepare, publish-native\]/)
+  assert.match(publish, /rm package-lock\.json/)
   assert.match(publish, /npm install --package-lock-only --ignore-scripts/)
   assert.match(publish, /git rm \.changeset\/publish-pending\.json/)
   assert.match(publish, /git add package-lock\.json/)


### PR DESCRIPTION
Discard the pre-publication optional-dependency lock entries before resolving the newly published native packages.