### PR TITLE
fix(ci): publish package directories by absolute path

### DIFF
--- a/scripts/release/publish-package.mjs
+++ b/scripts/release/publish-package.mjs
@@ -2,8 +2,9 @@ import { spawnSync } from 'node:child_process'
 import fs from 'node:fs'
 import path from 'node:path'
 
-const packageDirectory = process.argv[2]
-if (!packageDirectory) throw new Error('Usage: node scripts/release/publish-package.mjs <package-directory>')
+const packageDirectoryArgument = process.argv[2]
+if (!packageDirectoryArgument) throw new Error('Usage: node scripts/release/publish-package.mjs <package-directory>')
+const packageDirectory = path.resolve(packageDirectoryArgument)
 
 const manifestPath = path.join(packageDirectory, 'package.json')
 const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'))

--- a/test/release-contract.test.mjs
+++ b/test/release-contract.test.mjs
@@ -67,6 +67,7 @@ test('npm publishing is marker-gated, platform-complete, and cleans up in a seco
 test('npm publisher invokes Windows npm through a shell', () => {
   const publisher = readText('scripts/release/publish-package.mjs')
   assert.match(publisher, /shell: process\.platform === 'win32'/)
+  assert.match(publisher, /path\.resolve\(packageDirectoryArgument\)/)
 })
 
 test('publish verification is a no-op without the tracked release marker', () => {


### PR DESCRIPTION
Avoid npm interpreting the CLI workspace path as a GitHub shorthand when publishing.