### PR TITLE
fix(release): clean marker through pull request

### DIFF
--- a/.changeset/publish-pending.json
+++ b/.changeset/publish-pending.json
@@ -1,5 +1,0 @@
-{
-  "protocol": "tokenless.release-pending.v1",
-  "package": "tokenless",
-  "version": "0.2.0"
-}

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -10,6 +10,7 @@ on:
 permissions:
   contents: write
   id-token: write
+  pull-requests: write
 
 concurrency:
   group: tokenless-npm-publish
@@ -104,12 +105,14 @@ jobs:
           node-version: '24'
       - name: Remove the published release marker in a second commit
         env:
+          GH_TOKEN: ${{ github.token }}
           VERSION: ${{ needs.prepare.outputs.version }}
         run: |
+          CLEANUP_BRANCH="release/clear-publish-marker-$VERSION"
           git config user.name 'github-actions[bot]'
           git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
           git fetch origin main
-          git checkout -B main origin/main
+          git checkout -B "$CLEANUP_BRANCH" origin/main
           node scripts/release/verify-pending.mjs /tmp/release-output
           grep -Fx "version=$VERSION" /tmp/release-output
           rm package-lock.json
@@ -117,4 +120,10 @@ jobs:
           git rm .changeset/publish-pending.json
           git add package-lock.json
           git commit -m "chore(release): clear publish marker for tokenless@$VERSION"
-          git push origin HEAD:main
+          git push origin "HEAD:refs/heads/$CLEANUP_BRANCH"
+          PR_URL=$(gh pr create \
+            --base main \
+            --head "$CLEANUP_BRANCH" \
+            --title "chore(release): clear publish marker for tokenless@$VERSION" \
+            --body "- Clear the completed tokenless@$VERSION publish marker and refresh its release lockfile.")
+          gh pr merge "$PR_URL" --rebase --delete-branch

--- a/test/release-contract.test.mjs
+++ b/test/release-contract.test.mjs
@@ -59,6 +59,7 @@ test('npm publishing is marker-gated, platform-complete, and cleans up in a seco
   assert.match(prepare, /if: steps\.release-state\.outputs\.pending != 'true'/)
   assert.doesNotMatch(`${prepare}\n${publish}`, /npm ci/)
   assert.match(publish, /id-token: write/)
+  assert.match(publish, /pull-requests: write/)
   assert.doesNotMatch(publish, /NPM_TOKEN|_authToken|Configure npm token fallback/)
   assert.match(publish, /\.changeset\/publish-pending\.json/)
   assert.match(publish, /needs: \[prepare, publish-native\]/)
@@ -66,6 +67,9 @@ test('npm publishing is marker-gated, platform-complete, and cleans up in a seco
   assert.match(publish, /npm install --package-lock-only --ignore-scripts/)
   assert.match(publish, /git rm \.changeset\/publish-pending\.json/)
   assert.match(publish, /git add package-lock\.json/)
+  assert.match(publish, /gh pr create/)
+  assert.match(publish, /gh pr merge/)
+  assert.doesNotMatch(publish, /git push origin HEAD:main/)
   for (const [platform, arch] of [
     ['darwin', 'arm64'], ['darwin', 'x64'], ['linux', 'arm64'],
     ['linux', 'x64'], ['win32', 'arm64'], ['win32', 'x64'],


### PR DESCRIPTION
- Clear the completed tokenless@0.2.0 marker and route future release cleanup through a repository-rule-compatible pull request.