### PR TITLE
fix(cli): make tokenless upgrade runnable

### DIFF
--- a/.changeset/quick-upgrade-arrays.md
+++ b/.changeset/quick-upgrade-arrays.md
@@ -1,0 +1,5 @@
+---
+"tokenless": patch
+---
+
+Fix `tokenless upgrade --json` rejecting its default empty capability argument state before starting the upgrade workflow.

--- a/packages/cli/src/upgrade.ts
+++ b/packages/cli/src/upgrade.ts
@@ -249,10 +249,11 @@ function assertUpgradeArguments(args: UpgradeArgs) {
     'daemonStartTimeoutMs',
   ])
   const unsupported = Object.entries(args)
-    .filter(([key, value]) => value !== undefined && !allowed.has(key))
+    .filter(([key, value]) => !['attachFiles', 'capabilities', 'files'].includes(key) && value !== undefined && !allowed.has(key))
     .map(([key]) => `--${key.replace(/[A-Z]/g, (character) => `-${character.toLowerCase()}`)}`)
   if ((args.files?.length ?? 0) > 0) unsupported.push('--file')
   if ((args.attachFiles?.length ?? 0) > 0) unsupported.push('--attach-file')
+  if ((args.capabilities?.length ?? 0) > 0) unsupported.push('--capability')
   if (unsupported.length > 0) {
     throw upgradeUsageError(
       'upgrade_option_invalid',


### PR DESCRIPTION
- Fix the published upgrade workflow so its default empty capability collection is ignored during option validation.\n- Keep explicit unsupported capability options rejected with structured usage details before any upgrade side effect.\n- Add a patch Changeset for tokenless@0.4.1 and verify the build plus 22 package contract tests.